### PR TITLE
[master-CVE-3020]-NEEDS_TO_BE_SET: CVE-2025-30204 - Bump github.com/golang-jwt/jwt/v4 to version v4.5.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/go-openapi/swag v0.23.0
 	github.com/go-openapi/validate v0.24.0
 	github.com/golang-collections/go-datastructures v0.0.0-20150211160725-59788d5eb259
-	github.com/golang-jwt/jwt/v4 v4.5.0
+	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.6.0
 	github.com/google/renameio v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -518,8 +518,8 @@ github.com/golang-collections/go-datastructures v0.0.0-20150211160725-59788d5eb2
 github.com/golang-collections/go-datastructures v0.0.0-20150211160725-59788d5eb259/go.mod h1:9Qcha0gTWLw//0VNka1Cbnjvg3pNKGFdAm7E9sBabxE=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
-github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
-github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
+github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.1.2 h1:DVjP2PbBOzHyzA+dn3WhHIq4NdVu3Q+pvivFICf/7fo=

--- a/vendor/github.com/golang-jwt/jwt/v4/parser.go
+++ b/vendor/github.com/golang-jwt/jwt/v4/parser.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 )
 
+const tokenDelimiter = "."
+
 type Parser struct {
 	// If populated, only these methods will be considered valid.
 	//
@@ -36,19 +38,21 @@ func NewParser(options ...ParserOption) *Parser {
 	return p
 }
 
-// Parse parses, validates, verifies the signature and returns the parsed token.
-// keyFunc will receive the parsed token and should return the key for validating.
+// Parse parses, validates, verifies the signature and returns the parsed token. keyFunc will
+// receive the parsed token and should return the key for validating.
 func (p *Parser) Parse(tokenString string, keyFunc Keyfunc) (*Token, error) {
 	return p.ParseWithClaims(tokenString, MapClaims{}, keyFunc)
 }
 
-// ParseWithClaims parses, validates, and verifies like Parse, but supplies a default object implementing the Claims
-// interface. This provides default values which can be overridden and allows a caller to use their own type, rather
-// than the default MapClaims implementation of Claims.
+// ParseWithClaims parses, validates, and verifies like Parse, but supplies a default object
+// implementing the Claims interface. This provides default values which can be overridden and
+// allows a caller to use their own type, rather than the default MapClaims implementation of
+// Claims.
 //
-// Note: If you provide a custom claim implementation that embeds one of the standard claims (such as RegisteredClaims),
-// make sure that a) you either embed a non-pointer version of the claims or b) if you are using a pointer, allocate the
-// proper memory for it before passing in the overall claims, otherwise you might run into a panic.
+// Note: If you provide a custom claim implementation that embeds one of the standard claims (such
+// as RegisteredClaims), make sure that a) you either embed a non-pointer version of the claims or
+// b) if you are using a pointer, allocate the proper memory for it before passing in the overall
+// claims, otherwise you might run into a panic.
 func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyfunc) (*Token, error) {
 	token, parts, err := p.ParseUnverified(tokenString, claims)
 	if err != nil {
@@ -85,12 +89,17 @@ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyf
 		return token, &ValidationError{Inner: err, Errors: ValidationErrorUnverifiable}
 	}
 
+	// Perform validation
+	token.Signature = parts[2]
+	if err := token.Method.Verify(strings.Join(parts[0:2], "."), token.Signature, key); err != nil {
+		return token, &ValidationError{Inner: err, Errors: ValidationErrorSignatureInvalid}
+	}
+
 	vErr := &ValidationError{}
 
 	// Validate Claims
 	if !p.SkipClaimsValidation {
 		if err := token.Claims.Valid(); err != nil {
-
 			// If the Claims Valid returned an error, check if it is a validation error,
 			// If it was another error type, create a ValidationError with a generic ClaimsInvalid flag set
 			if e, ok := err.(*ValidationError); !ok {
@@ -98,22 +107,14 @@ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyf
 			} else {
 				vErr = e
 			}
+			return token, vErr
 		}
 	}
 
-	// Perform validation
-	token.Signature = parts[2]
-	if err = token.Method.Verify(strings.Join(parts[0:2], "."), token.Signature, key); err != nil {
-		vErr.Inner = err
-		vErr.Errors |= ValidationErrorSignatureInvalid
-	}
+	// No errors so far, token is valid.
+	token.Valid = true
 
-	if vErr.valid() {
-		token.Valid = true
-		return token, nil
-	}
-
-	return token, vErr
+	return token, nil
 }
 
 // ParseUnverified parses the token but doesn't validate the signature.
@@ -123,9 +124,10 @@ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyf
 // It's only ever useful in cases where you know the signature is valid (because it has
 // been checked previously in the stack) and you want to extract values from it.
 func (p *Parser) ParseUnverified(tokenString string, claims Claims) (token *Token, parts []string, err error) {
-	parts = strings.Split(tokenString, ".")
-	if len(parts) != 3 {
-		return nil, parts, NewValidationError("token contains an invalid number of segments", ValidationErrorMalformed)
+	var ok bool
+	parts, ok = splitToken(tokenString)
+	if !ok {
+		return nil, nil, NewValidationError("token contains an invalid number of segments", ValidationErrorMalformed)
 	}
 
 	token = &Token{Raw: tokenString}
@@ -174,4 +176,31 @@ func (p *Parser) ParseUnverified(tokenString string, claims Claims) (token *Toke
 	}
 
 	return token, parts, nil
+}
+
+// splitToken splits a token string into three parts: header, claims, and signature. It will only
+// return true if the token contains exactly two delimiters and three parts. In all other cases, it
+// will return nil parts and false.
+func splitToken(token string) ([]string, bool) {
+	parts := make([]string, 3)
+	header, remain, ok := strings.Cut(token, tokenDelimiter)
+	if !ok {
+		return nil, false
+	}
+	parts[0] = header
+	claims, remain, ok := strings.Cut(remain, tokenDelimiter)
+	if !ok {
+		return nil, false
+	}
+	parts[1] = claims
+	// One more cut to ensure the signature is the last part of the token and there are no more
+	// delimiters. This avoids an issue where malicious input could contain additional delimiters
+	// causing unecessary overhead parsing tokens.
+	signature, _, unexpected := strings.Cut(remain, tokenDelimiter)
+	if unexpected {
+		return nil, false
+	}
+	parts[2] = signature
+
+	return parts, true
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -357,7 +357,7 @@ github.com/golang-collections/go-datastructures/bitarray
 # github.com/golang-jwt/jwt v3.2.2+incompatible
 ## explicit
 github.com/golang-jwt/jwt
-# github.com/golang-jwt/jwt/v4 v4.5.0
+# github.com/golang-jwt/jwt/v4 v4.5.2
 ## explicit; go 1.16
 github.com/golang-jwt/jwt/v4
 # github.com/golang/glog v1.1.2


### PR DESCRIPTION

            Bump `github.com/golang-jwt/jwt/v4` to `v4.5.2` to fix `CVE-2025-30204`
            http://issues.redhat.com/browse/NEEDS_TO_BE_SET"
        